### PR TITLE
Reset Timer entry in the menu

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -210,8 +210,8 @@ MyApplet.prototype = {
     },
     
     // Reset the current running timer
-    _resetTimer: function() {
-        if (!this._stopTimer && this._isPause) {
+    _resetTimer: function() {       
+        if (!this._stopTimer && !this._isPause) {
             this._timeSpent = 0;
             this._updateTimer();
         }


### PR DESCRIPTION
Add the possibility to reset the timer through the menu.
It's useful when I'm interrupted in the middle of a pomodoro task and I need to restart it.
I can't use the "Reset Counts and Timer" because I want to keep my counts, I just want to reset the timer.
