### PR TITLE
Bug on duration changed

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -486,6 +486,7 @@ MyApplet.prototype = {
 
     on_pomodoro_duration_changed: function() {
         this._convertPomodoroDurationToSeconds();
+        this._timeSpent = 0;
         this._resetTimerDurations();
     },
 


### PR DESCRIPTION
When timer is off and the timer duration is changed in the settings, the new timer duration was not precisely display because the time spent was not reset.
