### PR TITLE
Fix JS error - assignment to undeclared variable

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -185,11 +185,6 @@ MyApplet.prototype = {
             y_align: St.Align.START
         });
 
-        this._dialog.contentLayout.add(this._descriptionLabel, {
-            x_fill: true,
-            y_fill: true
-        });
-
         this._dialog.setButtons([
             {
                 label: _("Switch Off Pomodoro"),


### PR DESCRIPTION
Turned-out to be a simple missing `let` statement
- Fixes #19
