### PR TITLE
Stop ticker sound when applet is removed from panel

### DIFF
--- a/pomodoro@gregfreeman.org/applet.js
+++ b/pomodoro@gregfreeman.org/applet.js
@@ -536,6 +536,7 @@ PomodoroApplet.prototype = {
     },
 
     on_applet_removed_from_panel: function() {
+        this._stopTickerSound();
         this._settingsProvider.finalize();
     }
 };


### PR DESCRIPTION
If ticker sound is enabled and you remove the applet from the panel the sound continue playing, this commit fixes that. It's a minor fix.