### PR TITLE
Reset timer queue state when applet is removed from panel

### DIFF
--- a/pomodoro@gregfreeman.org/applet.js
+++ b/pomodoro@gregfreeman.org/applet.js
@@ -536,7 +536,7 @@ PomodoroApplet.prototype = {
     },
 
     on_applet_removed_from_panel: function() {
-        this._stopTickerSound();
+        this._resetTimerQueueState();
         this._settingsProvider.finalize();
     }
 };


### PR DESCRIPTION
In the previous commit the ticking sound was stopped but Pomodoro kept running, so eventually sounds  started playing again even when there was no applet in panel. This commit resets the timer queue state so Pomodoro is stopped when applet is removed.