### PR TITLE
Refined (in my opinion(!)) the es Spanish translations.

### DIFF
--- a/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
+++ b/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
@@ -86,7 +86,7 @@ msgstr "Su descanso se ha terminado, ¡empiece otro Pomodoro!"
 
 #: applet.js:687
 msgid "A new pomodoro begins in "
-msgstr "Un Pomodoro Nuevo Comenzará en "
+msgstr "Un pomodoro nuevo comenzará en "
 
 #: applet.js:698
 #, c-format
@@ -143,8 +143,7 @@ msgstr "Archivo de Sonido de Descanso"
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->auto_start_after_break_ends->description
 msgid "Auto start a new pomodoro after a break ends"
-msgstr ""
-"Comenzar un pomodoro nuevo automáticamente después del fin de un descanso"
+msgstr "Comenzar un pomodoro nuevo automáticamente después del fin de un descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->timer_sound_file->description
@@ -162,7 +161,7 @@ msgstr "Retraso para Avisos (en segundos):  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->display_icon->description
 msgid "Display the pomodoro icon in the applet panel"
-msgstr "Mostrar el icono de pomodoro en el panel de applets"
+msgstr "Mostrar el ícono de pomodoro en el panel de applets"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->head_options->description
 msgid "Options"

--- a/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
+++ b/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-01-28 11:55-0500\n"
 "PO-Revision-Date: 2015-02-21 19:30-0800\n"
-"Last-Translator: Richard Decal <decal@uw.edu>\n"
+"Last-Translator: Ben Southall <stellarpower@googlemail.com>\n"
 "Language-Team: Richard Decal <decal@uw.edu>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,32 +24,32 @@ msgstr "Pomodoro iniciado"
 
 #: applet.js:316
 msgid "Take a short break"
-msgstr "Toma un descanso corto"
+msgstr "Tome un descanso corto"
 
 #: applet.js:325
 msgid "Take a long break"
-msgstr "Toma un descanso largo"
+msgstr "Tome un descanso largo"
 
 #: applet.js:355
 msgid "Pomodoro ended"
-msgstr "Fin del Pomodoro"
+msgstr "Fin del pomodoro"
 
 # applet menu
 #: applet.js:531
 msgid "Pomodoro Timer"
-msgstr "Reloj Pomodoro"
+msgstr "Temporizador Pomodoro"
 
 #: applet.js:542
 msgid "Completed"
-msgstr "Completo"
+msgstr "Completado"
 
 #: applet.js:555
 msgid "Reset Timer"
-msgstr "Restaura el reloj"
+msgstr "Reestablecer el Reloj"
 
 #: applet.js:567
 msgid "Reset Counts and Timer"
-msgstr "Restaura los conteos y el reloj"
+msgstr "Reestablecer las Cuentas y el Reloj"
 
 #: applet.js:580
 msgid "Settings"
@@ -57,36 +57,36 @@ msgstr "Configuración"
 
 #: applet.js:590
 msgid "What is this?"
-msgstr "Que es esto?"
+msgstr "¿Qué es esto?"
 
 #: applet.js:621
 msgid "None"
-msgstr "Nada"
+msgstr "Ninguno"
 
 # dialog
 #: applet.js:650
 msgid "Switch Off Pomodoro"
-msgstr "Apaga Pomodoro"
+msgstr "Apagar Pomodoro"
 
 #: applet.js:656
 msgid "Start a new Pomodoro"
-msgstr "Comencar un nuevo Pomodoro"
+msgstr "Comenzar un Pomodoro Nuevo"
 
 #: applet.js:662
 msgid "Hide"
-msgstr "Esconde"
+msgstr "Esconder"
 
 #: applet.js:674
 msgid "Pomodoro finished, you deserve a break!"
-msgstr "Pomodoro termino, mereces un descanso!"
+msgstr "Pomodoro terminado, ¡merece un descanso!"
 
 #: applet.js:682
 msgid "Your break is over, start another pomodoro!"
-msgstr "Tu descanso se termino, empiece otro Pomodoro!"
+msgstr "Su descanso se ha terminado, ¡empiece otro Pomodoro!"
 
 #: applet.js:687
 msgid "A new pomodoro begins in "
-msgstr "Un nuevo pomodoro comsa en "
+msgstr "Un Pomodoro Nuevo Comenzará en "
 
 #: applet.js:698
 #, c-format
@@ -96,60 +96,60 @@ msgstr "%d minutos y %d segundos"
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->pomodoro_duration->description
 msgid "Pomodoro Duration:  "
-msgstr "Duración del Pomodoro:"
+msgstr "Duración del Pomodoro:  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->warn_sound->description
 msgid "Play Warn Sound"
-msgstr "Tocar sonido de aviso"
+msgstr "Reproducir Sonido de Aviso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->long_break_duration->description
 msgid "Long Break Duration:  "
-msgstr "Duración del descanso llargo: "
+msgstr "Duración de Descansos Largos: "
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->show_dialog_messages->description
 msgid "Show Dialog Messages"
-msgstr "Mostrar mensajes de diálogo"
+msgstr "Mostrar Mensajes de Diálogo"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->pomodori_number->description
 msgid "Number of pomodori before long break:  "
-msgstr "Número de Pomodori antes del descanso llargo:  "
+msgstr "Número de pomodori antes de un descanso largo:  "
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->short_break_duration->description
 msgid "Short Break Duration:  "
-msgstr "Duración del descanso corto:  "
+msgstr "Duración de Descansos Cortos:  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->break_sound->description
 msgid "Play Break Sound"
-msgstr "Tocar sonido de descanso"
+msgstr "Reproducir Sonido de Descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->warn_sound_file->description
 msgid "Warn Sound File "
-msgstr "Archivo de sonido de aviso"
+msgstr "Archivo de Sonido de Aviso"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->timer_sound->description
 msgid "Play Timer Sound"
-msgstr "Tocar sonido de reloj"
+msgstr "Reproducir Sonido de Temporizador"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->break_sound_file->description
 msgid "Break Sound File "
-msgstr "Tocar sonido de descanso"
+msgstr "Archivo de Sonido de Descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->auto_start_after_break_ends->description
 msgid "Auto start a new pomodoro after a break ends"
 msgstr ""
-"Comenzar un nuevo Pomodoro automáticamente después del fin de descansos"
+"Comenzar un pomodoro nuevo automáticamente después del fin de un descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->timer_sound_file->description
 msgid "Timer Sound File "
-msgstr "Archivo de sonido de reloj"
+msgstr "Archivo de Sonido de Temporizador"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->head_sounds->description
 msgid "Sounds"
@@ -158,11 +158,11 @@ msgstr "Sonidos"
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->warn_sound_delay->description
 msgid "Warn Delay (in secs):  "
-msgstr "Retraso para avisos (en segundos):  "
+msgstr "Retraso para Avisos (en segundos):  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->display_icon->description
 msgid "Display the pomodoro icon in the applet panel"
-msgstr "Mostrar el icono en el panel de applets"
+msgstr "Mostrar el icono de pomodoro en el panel de applets"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->head_options->description
 msgid "Options"
@@ -170,4 +170,4 @@ msgstr "Opciones"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->head_durations->description
 msgid "Durations (minutes)"
-msgstr "Duracion (minutos)"
+msgstr "Duraciones (minutos)"

--- a/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
+++ b/pomodoro@gregfreeman.org/po/pomodoro@gregfreeman.org_es.po
@@ -37,7 +37,7 @@ msgstr "Fin del pomodoro"
 # applet menu
 #: applet.js:531
 msgid "Pomodoro Timer"
-msgstr "Temporizador Pomodoro"
+msgstr "Temporizador pomodoro"
 
 #: applet.js:542
 msgid "Completed"
@@ -45,11 +45,11 @@ msgstr "Completado"
 
 #: applet.js:555
 msgid "Reset Timer"
-msgstr "Reestablecer el Reloj"
+msgstr "Reestablecer el reloj"
 
 #: applet.js:567
 msgid "Reset Counts and Timer"
-msgstr "Reestablecer las Cuentas y el Reloj"
+msgstr "Reestablecer las cuentas y el reloj"
 
 #: applet.js:580
 msgid "Settings"
@@ -66,11 +66,11 @@ msgstr "Ninguno"
 # dialog
 #: applet.js:650
 msgid "Switch Off Pomodoro"
-msgstr "Apagar Pomodoro"
+msgstr "Apagar pomodoro"
 
 #: applet.js:656
 msgid "Start a new Pomodoro"
-msgstr "Comenzar un Pomodoro Nuevo"
+msgstr "Comenzar un pomodoro nuevo"
 
 #: applet.js:662
 msgid "Hide"
@@ -96,21 +96,21 @@ msgstr "%d minutos y %d segundos"
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->pomodoro_duration->description
 msgid "Pomodoro Duration:  "
-msgstr "Duración del Pomodoro:  "
+msgstr "Duración del pomodoro:  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->warn_sound->description
 msgid "Play Warn Sound"
-msgstr "Reproducir Sonido de Aviso"
+msgstr "Reproducir sonido de aviso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->long_break_duration->description
 msgid "Long Break Duration:  "
-msgstr "Duración de Descansos Largos: "
+msgstr "Duración de descansos largos: "
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->show_dialog_messages->description
 msgid "Show Dialog Messages"
-msgstr "Mostrar Mensajes de Diálogo"
+msgstr "Mostrar mensajes de diálogo"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->pomodori_number->description
@@ -120,25 +120,25 @@ msgstr "Número de pomodori antes de un descanso largo:  "
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->short_break_duration->description
 msgid "Short Break Duration:  "
-msgstr "Duración de Descansos Cortos:  "
+msgstr "Duración de descansos cortos:  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->break_sound->description
 msgid "Play Break Sound"
-msgstr "Reproducir Sonido de Descanso"
+msgstr "Reproducir sonido de descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->warn_sound_file->description
 msgid "Warn Sound File "
-msgstr "Archivo de Sonido de Aviso"
+msgstr "Archivo de sonido de aviso"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->timer_sound->description
 msgid "Play Timer Sound"
-msgstr "Reproducir Sonido de Temporizador"
+msgstr "Reproducir sonido de temporizador"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->break_sound_file->description
 msgid "Break Sound File "
-msgstr "Archivo de Sonido de Descanso"
+msgstr "Archivo de sonido de descanso"
 
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->auto_start_after_break_ends->description
@@ -148,7 +148,7 @@ msgstr "Comenzar un pomodoro nuevo automáticamente después del fin de un desca
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->timer_sound_file->description
 msgid "Timer Sound File "
-msgstr "Archivo de Sonido de Temporizador"
+msgstr "Archivo de sonido de temporizador"
 
 #. pomodoro@gregfreeman.org->settings-schema.json->head_sounds->description
 msgid "Sounds"
@@ -157,7 +157,7 @@ msgstr "Sonidos"
 #. pomodoro@gregfreeman.org->settings-
 #. schema.json->warn_sound_delay->description
 msgid "Warn Delay (in secs):  "
-msgstr "Retraso para Avisos (en segundos):  "
+msgstr "Retraso para avisos (en segundos):  "
 
 #. pomodoro@gregfreeman.org->settings-schema.json->display_icon->description
 msgid "Display the pomodoro icon in the applet panel"


### PR DESCRIPTION
Just tidied-up some of the translations, fixing spelling and punctuation errors (and as far as I can tell adding no more but I can double check for typos again later), rewording things slightly to give, in my opinion, a better sense of the original and changing a couple of Latin-American-specific words to standard Spanish. I've tried to copy the capitalisation and spacing exactly. If there are problems with the length of the strings I can cut them down slightly.