### PR TITLE
Implement pop after short break

### DIFF
--- a/pomodoro@gregfreeman.org/settings-schema.json
+++ b/pomodoro@gregfreeman.org/settings-schema.json
@@ -51,6 +51,12 @@
         "default" : true
     },
 
+    "auto_start_after_short_break_ends" : {
+        "type" : "checkbox",
+        "description" : "Auto start after a short break ends",
+        "default" : true
+    },
+
     "auto_start_after_break_ends" : {
         "type" : "checkbox",
         "description" : "Auto start a new pomodoro after a break ends",

--- a/pomodoro@gregfreeman.org/timer.js
+++ b/pomodoro@gregfreeman.org/timer.js
@@ -15,6 +15,7 @@ TimerQueue.prototype = {
         this._clearQueue();
         this._timerRunning = false;
         this._timerFinishedHandler = null;
+        this._timerPreventNextStart = false;
     },
 
     addTimer: function(timer) {
@@ -23,6 +24,10 @@ TimerQueue.prototype = {
 
     isRunning: function() {
         return this._timerRunning;
+    },
+
+    isStartPrevented: function() {
+        return this._timerPreventNextStart;
     },
 
     start: function() {
@@ -76,10 +81,18 @@ TimerQueue.prototype = {
         }
     },
 
+    preventStart: function (y) {
+        this._timerPreventNextStart = y
+    },
+
     _startNextTimer: function() {
         let timer = this.getCurrentTimer();
 
         if (timer == undefined) {
+            return false;
+        }
+
+        if (this.isStartPrevented()) {
             return false;
         }
 
@@ -107,6 +120,7 @@ TimerQueue.prototype = {
         }
 
         this._queuePos++;
+        this.emit('timer-queue-before-next-timer');
         this._startNextTimer();
     },
 


### PR DESCRIPTION
Gives user ability to choose from settings, a popup dialog after short break finishes, to start a new pomodori.
Respects "show_dialog_messages" setting.

Partially solves #25, #42. Instead of before a short break the popup dialog is after the short break.
Helpful in situations when you are unable to be in front of the computer before the break ends.
