### PR TITLE
Changed numerical values from scale to spinbutton to fix issue #67

### DIFF
--- a/pomodoro@gregfreeman.org/settings-schema.json
+++ b/pomodoro@gregfreeman.org/settings-schema.json
@@ -5,7 +5,7 @@
     },
 
     "pomodoro_duration": {
-        "type": "scale",
+        "type": "spinbutton",
         "default": 25,
         "min": 1,
         "max": 60,
@@ -14,7 +14,7 @@
     },
 
     "short_break_duration": {
-        "type": "scale",
+        "type": "spinbutton",
         "default": 5,
         "min": 1,
         "max": 15,
@@ -23,7 +23,7 @@
     },
 
     "long_break_duration": {
-        "type": "scale",
+        "type": "spinbutton",
         "default": 15,
         "min": 1,
         "max": 60,
@@ -32,7 +32,7 @@
     },
 
     "pomodori_number": {
-        "type": "scale",
+        "type": "spinbutton",
         "default": 4,
         "min": 1,
         "max": 10,
@@ -135,7 +135,7 @@
     },
 
     "warn_sound_delay": {
-        "type": "scale",
+        "type": "spinbutton",
         "default": 30,
         "min": 5,
         "max": 600,


### PR DESCRIPTION
Fixes #67:

In newer Cinnamon updates, the scale component is not displaying numbers
anymore, which makes it hard to pick the desired number of minutes we
want for a Pomodoro session for example.

This change replaces all "scale" components by "spinbutton" components
for selecting specific numbers (minutes or number of pomodori in a
session).

Tested on Cinnamon 3.2.7, not tested on previous versions (if someone can test for me it would be great).

![Settings panel screenshot](https://user-images.githubusercontent.com/471168/28172745-5cfa76ac-67e4-11e7-9a72-282c9977d3be.png)
